### PR TITLE
Bump to 0.1.4

### DIFF
--- a/addon/initializers/base-64-converter.js
+++ b/addon/initializers/base-64-converter.js
@@ -1,8 +1,10 @@
 import Base64converter from '../services/base-64-converter';
 
-export function initialize(application) {
+export function initialize() {
   var registerKey = 'service:base64converter';
   var registerName = 'base64converter';
+  
+  let application = arguments[1] || arguments[0];
 
   application.register(registerKey, Base64converter, {singleton: true});
 

--- a/addon/initializers/base-64-converter.js
+++ b/addon/initializers/base-64-converter.js
@@ -1,18 +1,17 @@
 import Base64converter from '../services/base-64-converter';
 
-export function initialize(container) {
+export function initialize(application) {
   var registerKey = 'service:base64converter';
   var registerName = 'base64converter';
-  var inject = container.injection.bind(container);
 
-  container.register(registerKey, Base64converter, {singleton: true});
+  application.register(registerKey, Base64converter, {singleton: true});
 
-  inject('controller', registerName, registerKey);
-  inject('component', registerName, registerKey);
-  inject('model', registerName, registerKey);
-  inject('route', registerName, registerKey);
-  inject('adapter', registerName, registerKey);
-  inject('serializer', registerName, registerKey);
+  application.inject('controller', registerName, registerKey);
+  application.inject('component', registerName, registerKey);
+  application.inject('model', registerName, registerKey);
+  application.inject('route', registerName, registerKey);
+  application.inject('adapter', registerName, registerKey);
+  application.inject('serializer', registerName, registerKey);
 }
 
 export default {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-base64-converter",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Since Ember 2.1, there are deprecations regarding the old use of initializers (see http://emberjs.com/deprecations/v2.x/#toc_initializer-arity).

This fixes it and bumps the NPM version to 0.1.4 :)
